### PR TITLE
fix(efcore-slow-query): use total duration milliseconds

### DIFF
--- a/dotnet/EFCoreUtils/src/EFCoreSlowQuery/EFCoreObserver.cs
+++ b/dotnet/EFCoreUtils/src/EFCoreSlowQuery/EFCoreObserver.cs
@@ -39,7 +39,7 @@ internal class SlowQueryObserver(ILogger logger, EFCoreSlowQueryOptions options)
     {
         if (value.Key == RelationalEventId.CommandExecuted.Name
             && value.Value is CommandExecutedEventData eventData
-            && eventData.Duration.Milliseconds > options.SlowQueryThresholdMilliseconds)
+            && eventData.Duration.TotalMilliseconds > options.SlowQueryThresholdMilliseconds)
         {
             if (options.RecordSlowQueryLog)
             {
@@ -60,7 +60,7 @@ internal class SlowQueryObserver(ILogger logger, EFCoreSlowQueryOptions options)
         if (logger.IsEnabled(options.LogLevel))
         {
             logger.Log(options.LogLevel, msg,
-                eventData.Duration.Milliseconds, options.ServiceName, eventData.Command.CommandText);
+                eventData.Duration.TotalMilliseconds, options.ServiceName, eventData.Command.CommandText);
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 63a785d0e416b3ae7fcbfce4f0d32adbb86b5ded. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Bug Fixes:
- Use the total command execution duration in milliseconds instead of the millisecond component when checking the slow-query threshold and writing slow-query logs.